### PR TITLE
Add delete insurance policy test

### DIFF
--- a/ApiUnitTests/InsurancePolicy.cs
+++ b/ApiUnitTests/InsurancePolicy.cs
@@ -55,5 +55,46 @@ namespace ApiUnitTests
             //Assert
             Assert.AreEqual(JsonConvert.SerializeObject(insurancePolicy), JsonConvert.SerializeObject(response));
         }
+
+        [TestMethod]
+        public void DeleteInsurancePolicy_RemovesPolicy()
+        {
+            // Arrange - add a policy first
+            var insurancePolicy = new Api.Models.InsurancePolicy()
+            {
+                PolicyNumber = 200,
+                PolicyEffectiveDate = DateTime.Now,
+                PolicyExpirationDate = DateTime.Now,
+                PrimaryInsuredPerson = new Api.Models.Person()
+                {
+                    FirstName = "John",
+                    LastName = "Doe",
+                    Address = "1 Test Way",
+                    City = "Testville",
+                    State = Api.Models.Location.StateEnum.PA,
+                    ZipCode = "00000"
+
+                },
+                RiskHome = new Api.Models.Home()
+                {
+                    RiskConstruction = Api.Models.Home.RiskContructionEnum.SingleWideManufacturedHome,
+                    RiskYearBuilt = 1999,
+                    Address = "",
+                    City = "",
+                    State = Api.Models.Location.StateEnum.PA,
+                    ZipCode = ""
+                }
+            };
+
+            // Add the policy using the controller
+            _controller.Post(insurancePolicy);
+
+            // Act - delete the policy
+            _controller.Delete(insurancePolicy.PolicyId);
+
+            // Assert - the repository should no longer return the policy
+            var deleted = _insurancePolicyRepository.Get(insurancePolicy.PolicyId);
+            Assert.AreEqual(0, deleted.Count);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend InsurancePolicy unit tests with a delete scenario

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d14fb828083208ffbb88e6fcc9d99