### PR TITLE
Update web API configuration comment

### DIFF
--- a/UserInterface/Service/Api.cs
+++ b/UserInterface/Service/Api.cs
@@ -17,7 +17,7 @@ namespace UserInterface.Service
             get
             {
                 return "http://localhost:51306/api/";
-                //return WebConfigurationManager.AppSettings["WebApiUrl"];
+                // TODO: read from configuration (e.g. appsettings.json)
             }
         }
 


### PR DESCRIPTION
## Summary
- revise comment about `WebApiUrl` setting because the base URL is hardcoded
- mention `appsettings.json` as the source of configuration

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d14f8849883208249adde24e98899