### PR TITLE
Fix RiskConstruction enum naming

### DIFF
--- a/Api/Code/InsurancePolicyRepository.cs
+++ b/Api/Code/InsurancePolicyRepository.cs
@@ -29,7 +29,7 @@ namespace Api.Code
                 },
                 RiskHome = new Models.Home()
                 {
-                    RiskConstruction = Models.Home.RiskContructionEnum.SingleWideManufacturedHome,
+                    RiskConstruction = Models.Home.RiskConstructionEnum.SingleWideManufacturedHome,
                     RiskYearBuilt = 2000,
                     Address = "123 Main Street",
                     City = "Macungie",
@@ -58,7 +58,7 @@ namespace Api.Code
                 },
                 RiskHome = new Models.Home()
                 {
-                    RiskConstruction = Models.Home.RiskContructionEnum.DoubleWideManufacturedHome,
+                    RiskConstruction = Models.Home.RiskConstructionEnum.DoubleWideManufacturedHome,
                     RiskYearBuilt = 1998,
                     Address = "50 Division Ave",
                     City = "Garfield",
@@ -87,7 +87,7 @@ namespace Api.Code
                 },
                 RiskHome = new Models.Home()
                 {
-                    RiskConstruction = Models.Home.RiskContructionEnum.ModularHome,
+                    RiskConstruction = Models.Home.RiskConstructionEnum.ModularHome,
                     RiskYearBuilt = 1980,
                     Address = "892 Banta Ave",
                     City = "Wicker",

--- a/Api/Models/Home.cs
+++ b/Api/Models/Home.cs
@@ -7,19 +7,19 @@ namespace Api.Models
     {
         //[Required]
         [Display(Name = "Construction Type")]
-        public RiskContructionEnum RiskConstruction { get; set; }
+        public RiskConstructionEnum RiskConstruction { get; set; }
 
         //[Required]
         //[Range(0, 2020)]
         [Display(Name = "Year Built")]
         public int RiskYearBuilt { get; set; }
 
-        public enum RiskContructionEnum
+        public enum RiskConstructionEnum
         {
             [Description("Modular Home")]
             ModularHome,
             [Description("Site Built Home")]
-            SiteBuiltHome,            
+            SiteBuiltHome,
             [Description("Single Wide Manufactured Home")]
             SingleWideManufacturedHome,
             [Description("Double Wide Manufactured Home")]

--- a/ApiUnitTests/InsurancePolicy.cs
+++ b/ApiUnitTests/InsurancePolicy.cs
@@ -40,7 +40,7 @@ namespace ApiUnitTests
                 },
                 RiskHome = new Api.Models.Home()
                 {
-                    RiskConstruction = Api.Models.Home.RiskContructionEnum.SingleWideManufacturedHome,
+                    RiskConstruction = Api.Models.Home.RiskConstructionEnum.SingleWideManufacturedHome,
                     RiskYearBuilt = 2000,
                     Address = "",
                     City = "",

--- a/UserInterface/Controllers/InsurancePolicyController.cs
+++ b/UserInterface/Controllers/InsurancePolicyController.cs
@@ -34,13 +34,13 @@ namespace UserInterface.Controllers
             #endregion
 
             #region Generate risk home construction enum            
-            var riskContructions = from Api.Models.Home.RiskContructionEnum e in Enum.GetValues(typeof(Api.Models.Home.RiskContructionEnum))
+            var riskConstructions = from Api.Models.Home.RiskConstructionEnum e in Enum.GetValues(typeof(Api.Models.Home.RiskConstructionEnum))
             select new
             {
                 ID = (int)e,
                 Name = UserInterface.Code.Enum.GetEnumDescription(e)
             };
-            ViewBag.RiskContructions = new SelectList(riskContructions, "ID", "Name");
+            ViewBag.RiskConstructions = new SelectList(riskConstructions, "ID", "Name");
             #endregion
 
             return View(new Api.Models.InsurancePolicy());

--- a/UserInterface/Views/InsurancePolicy/Add.cshtml
+++ b/UserInterface/Views/InsurancePolicy/Add.cshtml
@@ -79,7 +79,7 @@
                 <div class="panel-body">
                     <div class="form-group">
                         @Html.LabelFor(model => model.RiskHome.RiskConstruction)
-                        @Html.DropDownList("RiskHome.RiskConstruction", ViewBag.RiskContructions as SelectList, new { @class = "form-control", id = "RiskHome_RiskConstruction" })
+                        @Html.DropDownList("RiskHome.RiskConstruction", ViewBag.RiskConstructions as SelectList, new { @class = "form-control", id = "RiskHome_RiskConstruction" })
                     </div>
 
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- rename `RiskContructionEnum` to `RiskConstructionEnum`
- update property types and all references
- adjust UI controller/view to use new enum name
- update unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d14f2e9308320b933dfb716dc30ca