### PR TITLE
Fix policy list display

### DIFF
--- a/UserInterface/Views/InsurancePolicy/Index.cshtml
+++ b/UserInterface/Views/InsurancePolicy/Index.cshtml
@@ -34,7 +34,7 @@
                                             </button>
                                         </td>
                                         <td>
-                                            @insurancePolicy.PolicyId
+                                            @insurancePolicy.PolicyNumber
                                         </td>
                                         <td>
                                             @if (insurancePolicy.PrimaryInsuredPerson != null)


### PR DESCRIPTION
## Summary
- show PolicyNumber instead of PolicyId in insurance policy list

## Testing
- `dotnet test ApiUnitTests/ApiUnitTests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d0d73242483209067aa101cbde0d1